### PR TITLE
Initial check status

### DIFF
--- a/health.go
+++ b/health.go
@@ -32,6 +32,17 @@ func NewRegistry() *Registry {
 // the registry used by the HTTP handler.
 var DefaultRegistry *Registry
 
+// stringError defines a constant error as per https://dave.cheney.net/2016/04/07/constant-errors
+type stringError string
+
+// Initial check status to be used before a background check has been completed
+const initialStatus = stringError("not yet checked")
+
+// Error returns the error message, allowing stringError to be treated as an error
+func (e stringError) Error() string {
+	return string(e)
+}
+
 // Checker is the interface for a Health Checker
 type Checker interface {
 	// Check returns nil if the service is okay.
@@ -84,7 +95,7 @@ func (u *updater) Update(status error) {
 
 // NewStatusUpdater returns a new updater
 func NewStatusUpdater() Updater {
-	return &updater{}
+	return &updater{status: initialStatus}
 }
 
 // thresholdUpdater implements Checker and Updater, providing an asynchronous Update
@@ -127,7 +138,7 @@ func (tu *thresholdUpdater) Update(status error) {
 
 // NewThresholdStatusUpdater returns a new thresholdUpdater
 func NewThresholdStatusUpdater(t int) Updater {
-	return &thresholdUpdater{threshold: t}
+	return &thresholdUpdater{count: t, status: initialStatus, threshold: t}
 }
 
 // PeriodicChecker wraps an updater to provide a periodic checker

--- a/health_test.go
+++ b/health_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 // TestReturns200IfThereAreNoChecks ensures that the result code of the health
@@ -94,8 +95,11 @@ func TestHealthHandler(t *testing.T) {
 		}
 	}
 
+	checkDown(t, "initial health check") // should be down initially, and the first check update will set to the correct state later
+
 	// server should be up
-	checkUp(t, "initial health check")
+	updater.Update(nil)
+	checkUp(t, "after successful check")
 
 	// now, we fail the health check
 	updater.Update(fmt.Errorf("the server is now out of commission"))
@@ -104,4 +108,262 @@ func TestHealthHandler(t *testing.T) {
 	// bring server back up
 	updater.Update(nil)
 	checkUp(t, "when server is back up") // now we should be back up.
+}
+
+func TestNewThresholdStatusUpdater(t *testing.T) {
+	testData := []struct {
+		Name           string
+		CheckThreshold int
+		PrepareState   func(up Updater)
+		ExpectedError  error
+	}{
+		{
+			Name:           "Not yet checked",
+			CheckThreshold: 1,
+			PrepareState:   func(up Updater) {},
+			ExpectedError:  errors.New("not yet checked"),
+		},
+		{
+			Name:           "Successful check",
+			CheckThreshold: 1,
+			PrepareState: func(up Updater) {
+				up.Update(nil)
+			},
+		},
+		{
+			Name:           "Failing check",
+			CheckThreshold: 1,
+			PrepareState: func(up Updater) {
+				up.Update(errors.New("failing check"))
+			},
+			ExpectedError: errors.New("failing check"),
+		},
+		{
+			Name:           "Under threshold",
+			CheckThreshold: 3,
+			PrepareState: func(up Updater) {
+				err := errors.New("failing check")
+				up.Update(err)
+				up.Update(err)
+			},
+			ExpectedError: errors.New("failing check"),
+		},
+		{
+			Name:           "Reaches threshold",
+			CheckThreshold: 3,
+			PrepareState: func(up Updater) {
+				err := errors.New("failing check")
+				up.Update(err)
+				up.Update(err)
+				up.Update(err)
+			},
+			ExpectedError: errors.New("failing check"),
+		},
+		{
+			Name:           "Reaches threshold, then succeeds",
+			CheckThreshold: 3,
+			PrepareState: func(up Updater) {
+				err := errors.New("failing check")
+				up.Update(err)
+				up.Update(err)
+				up.Update(err)
+				up.Update(nil)
+			},
+		},
+		{
+			Name:           "Count resets with success",
+			CheckThreshold: 3,
+			PrepareState: func(up Updater) {
+				err := errors.New("failing check")
+				up.Update(err)
+				up.Update(err)
+				up.Update(err)
+				up.Update(nil)
+				// We fail twice more, but this isn't enough to push passed the threshold again (since the success reset the count)
+				up.Update(err)
+				up.Update(err)
+			},
+		},
+	}
+
+	for _, d := range testData {
+		t.Run(d.Name, func(t *testing.T) {
+			up := NewThresholdStatusUpdater(d.CheckThreshold)
+
+			d.PrepareState(up)
+
+			err := up.Check()
+
+			if d.ExpectedError != nil {
+				if err == nil || d.ExpectedError.Error() != err.Error() {
+					t.Fatalf("Expected [%+v] but found [%+v]", d.ExpectedError, err)
+				}
+			} else if d.ExpectedError == nil && err != nil {
+				t.Fatalf("Check failed: %+v", err)
+			}
+		})
+	}
+}
+
+func TestPeriodicChecker(t *testing.T) {
+	okFunc := func() error { return nil }
+	errFunc := func() error { return errors.New("failing check") }
+
+	testData := []struct {
+		Name          string
+		CheckFunc     CheckFunc
+		CheckPeriod   time.Duration
+		VerifyAfter   time.Duration
+		ExpectedError error
+	}{
+		{
+			Name:          "Not yet checked",
+			CheckFunc:     okFunc,
+			CheckPeriod:   5 * time.Second,
+			VerifyAfter:   10 * time.Millisecond,
+			ExpectedError: errors.New("not yet checked"),
+		},
+		{
+			Name:        "Successful check",
+			CheckFunc:   okFunc,
+			CheckPeriod: 5 * time.Millisecond,
+			VerifyAfter: 100 * time.Millisecond,
+		},
+		{
+			Name:          "Failing check",
+			CheckFunc:     errFunc,
+			CheckPeriod:   5 * time.Millisecond,
+			VerifyAfter:   100 * time.Millisecond,
+			ExpectedError: errors.New("failing check"),
+		},
+		{
+			Name:          "Fail from 3rd check onwards",
+			CheckFunc:     succeedUntil(3, func() error { return errors.New("delayed failure") }),
+			CheckPeriod:   5 * time.Millisecond,
+			VerifyAfter:   100 * time.Millisecond,
+			ExpectedError: errors.New("delayed failure"),
+		},
+	}
+
+	for _, d := range testData {
+		t.Run(d.Name, func(t *testing.T) {
+			pc := PeriodicChecker(d.CheckFunc, d.CheckPeriod)
+
+			<-time.After(d.VerifyAfter)
+
+			err := pc.Check()
+
+			if d.ExpectedError != nil {
+				if err == nil || d.ExpectedError.Error() != err.Error() {
+					t.Fatalf("Expected [%+v] but found [%+v]", d.ExpectedError, err)
+				}
+			} else if d.ExpectedError == nil && err != nil {
+				t.Fatalf("Check failed: %+v", err)
+			}
+		})
+	}
+}
+
+func TestNewPeriodicThresholdChecker(t *testing.T) {
+	okFunc := func() error { return nil }
+	errFunc := func() error { return errors.New("failing check") }
+	// Health check that will fail regularly, but never enough in a row to reach the failure threshold
+	underThresholdCheck := func(threshold int) CheckFunc {
+		// Set the initial failure count to the threshold, as we need to clear the initial check state with an immediate success before we continue
+		failCount := threshold
+		maxFailures := threshold - 1
+		return func() error {
+			if failCount < maxFailures {
+				failCount++
+				return fmt.Errorf("fail [%d] threshold [%d]", failCount, threshold)
+			}
+
+			failCount = 0
+			return nil
+		}
+	}
+
+	testData := []struct {
+		Name           string
+		CheckFunc      CheckFunc
+		CheckPeriod    time.Duration
+		CheckThreshold int
+		VerifyAfter    time.Duration
+		VerifyTimes    int
+		ExpectedError  error
+	}{
+		{
+			Name:           "Not yet checked",
+			CheckFunc:      okFunc,
+			CheckPeriod:    5 * time.Second,
+			CheckThreshold: 3,
+			VerifyAfter:    10 * time.Millisecond,
+			VerifyTimes:    1,
+			ExpectedError:  errors.New("not yet checked"),
+		},
+		{
+			Name:           "Always successful check",
+			CheckFunc:      okFunc,
+			CheckPeriod:    5 * time.Millisecond,
+			VerifyAfter:    100 * time.Millisecond,
+			VerifyTimes:    1,
+			CheckThreshold: 3,
+		},
+		{
+			Name:           "Always failing check",
+			CheckFunc:      errFunc,
+			CheckPeriod:    5 * time.Millisecond,
+			CheckThreshold: 3,
+			VerifyAfter:    100 * time.Millisecond,
+			VerifyTimes:    1,
+			ExpectedError:  errors.New("failing check"),
+		},
+		// Due to the nature of a periodic threshold check, verifying proper behaviour around the threshold / reset is
+		// difficult. To increase confidence in correctness, we do the following:
+		// * Run verification multiple times
+		// * Slow the check period relative to the assert frequency (ensuring fewer checks between assertions)
+		// * Use a threshold of 2 such that we would reach the threshold as often as possible
+		{
+			Name:           "Always under threshold",
+			CheckFunc:      underThresholdCheck(2),
+			CheckPeriod:    20 * time.Millisecond,
+			CheckThreshold: 2,
+			VerifyAfter:    50 * time.Millisecond,
+			VerifyTimes:    10,
+		},
+	}
+
+	for _, d := range testData {
+		t.Run(d.Name, func(t *testing.T) {
+			pc := PeriodicThresholdChecker(d.CheckFunc, d.CheckPeriod, d.CheckThreshold)
+
+			if d.VerifyTimes <= 0 {
+				t.Fatalf("Verify times [%v] must be at least 1", d.VerifyTimes)
+			}
+			for i := 0; i < d.VerifyTimes; i++ {
+				<-time.After(d.VerifyAfter)
+
+				err := pc.Check()
+
+				if d.ExpectedError != nil {
+					if err == nil || d.ExpectedError.Error() != err.Error() {
+						t.Fatalf("Expected [%+v] but found [%+v]", d.ExpectedError, err)
+					}
+				} else if d.ExpectedError == nil && err != nil {
+					t.Fatalf("Check failed: %+v", err)
+				}
+			}
+		})
+	}
+}
+
+func succeedUntil(checkCount int, then CheckFunc) CheckFunc {
+	check := 0
+	return func() error {
+		if check < checkCount {
+			check++
+			return nil
+		}
+		return then()
+	}
 }


### PR DESCRIPTION
Setting initial state of updaters to be in a special error state that signifies that the first check has not completed yet. This treats the health of that check to be 'unhealthy' since 'health' has not yet been established

This behaviour is used to prevent falsely returning 'healthy' when an application first starts (i.e. when we've not yet established that to be the case) which avoids bringing an application into service that will not actually be 'healthy' shortly afterward

Signed-off-by: David Ackroyd <daveo.ackroyd@gmail.com>