### PR TITLE
Fix README.md with proper import settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ immediately. This pattern is particularly useful for checks that verify upstream
 
 To install go-healthcheck, just import it in your application:
 
-`import "github.com/docker/go-healthcheck/health"`
+`import "github.com/docker/go-healthcheck"`
 
-You can also (optionally) import `health/api` that will add two convenience endpoints: `/debug/health/down` and `/debug/health/up`. These endpoints add "manual" checks that allow the service to quickly be brought in/out of rotation.
+You can also (optionally) import `api` that will add two convenience endpoints: `/debug/health/down` and `/debug/health/up`. These endpoints add "manual" checks that allow the service to quickly be brought in/out of rotation.
 
-`import _ "github.com/docker/go-healthcheck/health/api"`
+`import _ "github.com/docker/go-healthcheck/api"`
 
 ```bash
 # curl localhost:5001/debug/health
@@ -84,7 +84,7 @@ You could also use the health checker mechanism to ensure your application only 
 
 You can also use the predefined Checkers that come included with the health package. First, import the checks:
 
-`import "github.com/docker/distribution/health/checks`
+`import "github.com/docker/distribution/checks`
 
 After that you can make use of any of the provided checks. An example of using a `FileChecker` to take the application out of rotation if a certain file exists can be done as follows:
 


### PR DESCRIPTION
Import documentation wrongly specified `health` in the path.